### PR TITLE
CSDR-737: enable code coverage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val wartremoverSettings =
 lazy val scoverageSettings =
   Seq(
     ScoverageKeys.coverageExcludedPackages := "<empty>;.*Reverse.*;.*(config|views.*);.*(BuildInfo|Routes).*",
-    ScoverageKeys.coverageMinimum := 80.00,
+    ScoverageKeys.coverageMinimum := 73.00,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true,
     coverageEnabled.in(ThisBuild, Test, test) := true


### PR DESCRIPTION
Set minimum coverage to lower than current as baseline we can build up from.