### PR TITLE
Revert "CDSR-958 Renamed "Risk Classification Error" to "Incorrect Additional Information Code" "

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaim/models/eis/claim/enums/BasisOfClaim.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/models/eis/claim/enums/BasisOfClaim.scala
@@ -58,7 +58,7 @@ object BasisOfClaim {
     case ProofOfReturnRefundGiven               => "Proof of Return/Refund Given"
     case EvidenceThatGoodsHaveNotEnteredTheEU   => "Evidence That Goods Have Not Entered The EU"
     case IncorrectExciseValue                   => "Incorrect Excise Value"
-    case CorrectionToRiskClassification         => "Incorrect Additional Information Code"
+    case CorrectionToRiskClassification         => "Risk Classification Error"
   }
   // $COVERAGE-ON$
 


### PR DESCRIPTION
Reverts hmrc/cds-reimbursement-claim#79