### PR TITLE
CDSR-1030 Making basis of claims mandatory

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaim/models/claim/CompleteClaim.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/models/claim/CompleteClaim.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.cdsreimbursementclaim.models.claim
 
 import cats.data.NonEmptyList
 import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.BasisOfClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.BasisOfClaimAnswer
 import uk.gov.hmrc.cdsreimbursementclaim.models.ids.MRN
 import uk.gov.hmrc.cdsreimbursementclaim.utils.MoneyUtils._
 
@@ -33,7 +33,7 @@ final case class CompleteClaim(
   detailsRegisteredWithCdsAnswer: DetailsRegisteredWithCdsAnswer,
   mrnContactDetailsAnswer: Option[MrnContactDetails],
   mrnContactAddressAnswer: Option[ContactAddress],
-  basisOfClaimAnswer: Option[BasisOfClaim],
+  basisOfClaimAnswer: BasisOfClaimAnswer,
   bankAccountDetailsAnswer: Option[BankAccountDetails],
   supportingEvidencesAnswer: SupportingEvidencesAnswer,
   commodityDetailsAnswer: CommodityDetailsAnswer,

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/models/eis/claim/enums/BasisOfClaimAnswer.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/models/eis/claim/enums/BasisOfClaimAnswer.scala
@@ -20,30 +20,30 @@ import cats.Eq
 import julienrf.json.derived
 import play.api.libs.json.OFormat
 
-sealed trait BasisOfClaim extends Product with Serializable
+sealed trait BasisOfClaimAnswer extends Product with Serializable
 
-object BasisOfClaim {
+object BasisOfClaimAnswer {
 
-  case object DuplicateEntry extends BasisOfClaim
-  case object DutySuspension extends BasisOfClaim
-  case object EndUseRelief extends BasisOfClaim
-  case object IncorrectCommodityCode extends BasisOfClaim
-  case object IncorrectCpc extends BasisOfClaim
-  case object IncorrectValue extends BasisOfClaim
-  case object IncorrectEoriAndDefermentAccountNumber extends BasisOfClaim
-  case object InwardProcessingReliefFromCustomsDuty extends BasisOfClaim
-  case object Miscellaneous extends BasisOfClaim
-  case object OutwardProcessingRelief extends BasisOfClaim
-  case object PersonalEffects extends BasisOfClaim
-  case object Preference extends BasisOfClaim
-  case object RGR extends BasisOfClaim
-  case object ProofOfReturnRefundGiven extends BasisOfClaim
-  case object EvidenceThatGoodsHaveNotEnteredTheEU extends BasisOfClaim
-  case object IncorrectExciseValue extends BasisOfClaim
-  case object IncorrectAdditionalInformationCode extends BasisOfClaim
+  case object DuplicateEntry extends BasisOfClaimAnswer
+  case object DutySuspension extends BasisOfClaimAnswer
+  case object EndUseRelief extends BasisOfClaimAnswer
+  case object IncorrectCommodityCode extends BasisOfClaimAnswer
+  case object IncorrectCpc extends BasisOfClaimAnswer
+  case object IncorrectValue extends BasisOfClaimAnswer
+  case object IncorrectEoriAndDefermentAccountNumber extends BasisOfClaimAnswer
+  case object InwardProcessingReliefFromCustomsDuty extends BasisOfClaimAnswer
+  case object Miscellaneous extends BasisOfClaimAnswer
+  case object OutwardProcessingRelief extends BasisOfClaimAnswer
+  case object PersonalEffects extends BasisOfClaimAnswer
+  case object Preference extends BasisOfClaimAnswer
+  case object RGR extends BasisOfClaimAnswer
+  case object ProofOfReturnRefundGiven extends BasisOfClaimAnswer
+  case object EvidenceThatGoodsHaveNotEnteredTheEU extends BasisOfClaimAnswer
+  case object IncorrectExciseValue extends BasisOfClaimAnswer
+  case object IncorrectAdditionalInformationCode extends BasisOfClaimAnswer
 
   // $COVERAGE-OFF$
-  def basisOfClaimToString(basisForClaim: BasisOfClaim): String = basisForClaim match {
+  def basisOfClaimToString(basisForClaim: BasisOfClaimAnswer): String = basisForClaim match {
     case DuplicateEntry                         => "Duplicate Entry"
     case DutySuspension                         => "Duty Suspension"
     case EndUseRelief                           => "End Use"
@@ -64,8 +64,8 @@ object BasisOfClaim {
   }
   // $COVERAGE-ON$
 
-  implicit val eq: Eq[BasisOfClaim] = Eq.fromUniversalEquals
+  implicit val eq: Eq[BasisOfClaimAnswer] = Eq.fromUniversalEquals
 
-  implicit val format: OFormat[BasisOfClaim] = derived.oformat[BasisOfClaim]()
+  implicit val format: OFormat[BasisOfClaimAnswer] = derived.oformat[BasisOfClaimAnswer]()
 
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/ClaimTransformerService.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/ClaimTransformerService.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.cdsreimbursementclaim.models.claim.ReimbursementMethodAnswer.
 import uk.gov.hmrc.cdsreimbursementclaim.models.claim.{ClaimedReimbursementsAnswer, Address => _, BankDetails => _, NdrcDetails => _, _}
 import uk.gov.hmrc.cdsreimbursementclaim.models.dates.DateGenerator
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim._
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.BasisOfClaim.IncorrectAdditionalInformationCode
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.BasisOfClaimAnswer.IncorrectAdditionalInformationCode
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums._
 import uk.gov.hmrc.cdsreimbursementclaim.models.ids.{MRN, UUIDGenerator}
 import uk.gov.hmrc.cdsreimbursementclaim.models.{Error, Validation}
@@ -342,19 +342,15 @@ object DefaultClaimTransformerService {
     )
 
   def makeReasonAndOrBasisOfClaim(
-    maybeBasisOfClaim: Option[BasisOfClaim],
+    basisOfClaim: BasisOfClaimAnswer,
     enableCorrectAdditionalInformationCodeMapping: Boolean
   ): Validation[Option[String]] =
-    maybeBasisOfClaim match {
-      case Some(basisOfClaim) =>
-        if (enableCorrectAdditionalInformationCodeMapping && basisOfClaim === IncorrectAdditionalInformationCode) {
-          Valid(Some(BasisOfClaim.basisOfClaimToString(basisOfClaim)))
-        } else if (basisOfClaim === IncorrectAdditionalInformationCode) {
-          Valid(Some("Risk Classification Error"))
-        } else {
-          Valid(Some(BasisOfClaim.basisOfClaimToString(basisOfClaim)))
-        }
-      case None               => invalidNel("Could not find basis of claim")
+    if (enableCorrectAdditionalInformationCodeMapping && basisOfClaim === IncorrectAdditionalInformationCode) {
+      Valid(Some(BasisOfClaimAnswer.basisOfClaimToString(basisOfClaim)))
+    } else if (basisOfClaim === IncorrectAdditionalInformationCode) {
+      Valid(Some("Risk Classification Error"))
+    } else {
+      Valid(Some(BasisOfClaimAnswer.basisOfClaimToString(basisOfClaim)))
     }
 
   def buildConsigneeEstablishmentAddress(

--- a/test/uk/gov/hmrc/cdsreimbursementclaim/models/generators/CompleteClaimGen.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaim/models/generators/CompleteClaimGen.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.cdsreimbursementclaim.models.claim.CompleteClaim
 import uk.gov.hmrc.cdsreimbursementclaim.models.claim.ClaimedReimbursementsAnswer
 import uk.gov.hmrc.cdsreimbursementclaim.models.claim._
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.MRNInformation
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.BasisOfClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.BasisOfClaimAnswer
 
 object CompleteClaimGen {
 
@@ -35,7 +35,7 @@ object CompleteClaimGen {
   implicit val bankAccountDetailsAnswerGen: Typeclass[BankAccountDetails]                   =
     gen[BankAccountDetails]
   implicit val mrnInformationGen: Typeclass[MRNInformation]                                 = gen[MRNInformation]
-  implicit val basisOfClaimAnswerGen: Typeclass[BasisOfClaim]                               = gen[BasisOfClaim]
+  implicit val basisOfClaimAnswerGen: Typeclass[BasisOfClaimAnswer]                         = gen[BasisOfClaimAnswer]
   implicit val declarantTypeAnswerGen: Typeclass[DeclarantTypeAnswer]                       = gen[DeclarantTypeAnswer]
   implicit val completeClaimGen: Typeclass[CompleteClaim]                                   = gen[CompleteClaim]
 }

--- a/test/uk/gov/hmrc/cdsreimbursementclaim/services/ClaimTransformerServiceSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaim/services/ClaimTransformerServiceSpec.scala
@@ -144,7 +144,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
 
         val bankAccountDetailsAnswer: BankAccountDetails = sample[BankAccountDetails]
 
-        val basisOfClaimAnswer = BasisOfClaim.DutySuspension
+        val basisOfClaimAnswer = BasisOfClaimAnswer.DutySuspension
 
         val declarantTypeAnswer       = DeclarantTypeAnswer.Importer
         val movevementReferenceNumber = MRN("10ABCDEFGHIJKLMNO0")
@@ -153,7 +153,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
           sample[CompleteClaim].copy(
             movementReferenceNumber = movevementReferenceNumber,
             declarantTypeAnswer = declarantTypeAnswer,
-            basisOfClaimAnswer = Some(basisOfClaimAnswer),
+            basisOfClaimAnswer = basisOfClaimAnswer,
             bankAccountDetailsAnswer = Some(bankAccountDetailsAnswer),
             claimedReimbursementsAnswer = claimedReimbursementsAnswer,
             displayDeclaration = Some(displayDeclaration)
@@ -810,7 +810,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
         val amounts                                      = getClaimAmounts
         val claimedReimbursementsAnswer                  = ClaimedReimbursementsAnswer(amounts)
         val bankAccountDetailsAnswer: BankAccountDetails = sample[BankAccountDetails]
-        val basisOfClaimAnswer                           = BasisOfClaim.DutySuspension
+        val basisOfClaimAnswer                           = BasisOfClaimAnswer.DutySuspension
         val declarantTypeAnswer                          = declarantType
         val completeMovementReferenceNumberAnswer        = MRN("10ABCDEFGHIJKLMNO0")
         val detailsRegisteredWithCds                     =
@@ -823,7 +823,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
             detailsRegisteredWithCdsAnswer = detailsRegisteredWithCds,
             mrnContactDetailsAnswer = Some(contactDetails),
             mrnContactAddressAnswer = Some(contactAddress),
-            basisOfClaimAnswer = Some(basisOfClaimAnswer),
+            basisOfClaimAnswer = basisOfClaimAnswer,
             bankAccountDetailsAnswer = Some(bankAccountDetailsAnswer),
             claimedReimbursementsAnswer = claimedReimbursementsAnswer,
             displayDeclaration = Some(displayDeclaration),
@@ -899,7 +899,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
         val amounts                                      = getClaimAmounts
         val claimedReimbursementsAnswer                  = ClaimedReimbursementsAnswer(amounts)
         val bankAccountDetailsAnswer: BankAccountDetails = sample[BankAccountDetails]
-        val basisOfClaimAnswer                           = BasisOfClaim.DutySuspension
+        val basisOfClaimAnswer                           = BasisOfClaimAnswer.DutySuspension
         val declarantTypeAnswer                          = declarantType
         val completeMovementReferenceNumberAnswer        = MRN("10ABCDEFGHIJKLMNO0")
         val detailsRegisteredWithCds                     =
@@ -912,7 +912,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
             detailsRegisteredWithCdsAnswer = detailsRegisteredWithCds,
             mrnContactDetailsAnswer = None,
             mrnContactAddressAnswer = None,
-            basisOfClaimAnswer = Some(basisOfClaimAnswer),
+            basisOfClaimAnswer = basisOfClaimAnswer,
             bankAccountDetailsAnswer = Some(bankAccountDetailsAnswer),
             claimedReimbursementsAnswer = claimedReimbursementsAnswer,
             displayDeclaration = Some(displayDeclaration),
@@ -966,7 +966,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
         val amounts                                      = getClaimAmounts
         val claimedReimbursementsAnswer                  = ClaimedReimbursementsAnswer(amounts)
         val bankAccountDetailsAnswer: BankAccountDetails = sample[BankAccountDetails]
-        val basisOfClaimAnswer                           = BasisOfClaim.DutySuspension
+        val basisOfClaimAnswer                           = BasisOfClaimAnswer.DutySuspension
         val declarantTypeAnswer                          = declarantType
         val completeMovementReferenceNumberAnswer        = MRN("10ABCDEFGHIJKLMNO0")
         val detailsRegisteredWithCds                     =
@@ -979,7 +979,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
             detailsRegisteredWithCdsAnswer = detailsRegisteredWithCds,
             mrnContactDetailsAnswer = Some(contactDetails),
             mrnContactAddressAnswer = Some(contactAddress),
-            basisOfClaimAnswer = Some(basisOfClaimAnswer),
+            basisOfClaimAnswer = basisOfClaimAnswer,
             bankAccountDetailsAnswer = Some(bankAccountDetailsAnswer),
             claimedReimbursementsAnswer = claimedReimbursementsAnswer,
             displayDeclaration = Some(displayDeclaration),
@@ -1026,7 +1026,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
         val amounts                                      = getClaimAmounts
         val claimedReimbursementsAnswer                  = ClaimedReimbursementsAnswer(amounts)
         val bankAccountDetailsAnswer: BankAccountDetails = sample[BankAccountDetails]
-        val basisOfClaimAnswer                           = BasisOfClaim.DutySuspension
+        val basisOfClaimAnswer                           = BasisOfClaimAnswer.DutySuspension
         val declarantTypeAnswer                          = declarantType
         val completeMovementReferenceNumberAnswer        = MRN("10ABCDEFGHIJKLMNO0")
         val detailsRegisteredWithCds                     =
@@ -1039,7 +1039,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
             detailsRegisteredWithCdsAnswer = detailsRegisteredWithCds,
             mrnContactDetailsAnswer = None,
             mrnContactAddressAnswer = None,
-            basisOfClaimAnswer = Some(basisOfClaimAnswer),
+            basisOfClaimAnswer = basisOfClaimAnswer,
             bankAccountDetailsAnswer = Some(bankAccountDetailsAnswer),
             claimedReimbursementsAnswer = claimedReimbursementsAnswer,
             displayDeclaration = Some(displayDeclaration),
@@ -1093,7 +1093,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
         val amounts                                      = getClaimAmounts
         val claimedReimbursementsAnswer                  = ClaimedReimbursementsAnswer(amounts)
         val bankAccountDetailsAnswer: BankAccountDetails = sample[BankAccountDetails]
-        val basisOfClaim                                 = BasisOfClaim.DutySuspension
+        val basisOfClaimAnswer                           = BasisOfClaimAnswer.DutySuspension
         val declarantTypeAnswer                          = declarantType
         val completeMovementReferenceNumberAnswer        = MRN("10ABCDEFGHIJKLMNO0")
         val detailsRegisteredWithCds                     =
@@ -1106,7 +1106,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
             detailsRegisteredWithCdsAnswer = detailsRegisteredWithCds,
             mrnContactDetailsAnswer = Some(contactDetails),
             mrnContactAddressAnswer = Some(contactAddress),
-            basisOfClaimAnswer = Some(basisOfClaim),
+            basisOfClaimAnswer = basisOfClaimAnswer,
             bankAccountDetailsAnswer = Some(bankAccountDetailsAnswer),
             claimedReimbursementsAnswer = claimedReimbursementsAnswer,
             displayDeclaration = Some(displayDeclaration),
@@ -1154,7 +1154,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
         val amounts                                      = getClaimAmounts
         val claimedReimbursementsAnswer                  = ClaimedReimbursementsAnswer(amounts)
         val bankAccountDetailsAnswer: BankAccountDetails = sample[BankAccountDetails]
-        val basisOfClaimAnswer                           = BasisOfClaim.DutySuspension
+        val basisOfClaimAnswer                           = BasisOfClaimAnswer.DutySuspension
         val declarantTypeAnswer                          = declarantType
         val completeMovementReferenceNumberAnswer        = MRN("10ABCDEFGHIJKLMNO0")
         val detailsRegisteredWithCds                     =
@@ -1167,7 +1167,7 @@ class ClaimTransformerServiceSpec extends AnyWordSpec with Matchers with MockFac
             detailsRegisteredWithCdsAnswer = detailsRegisteredWithCds,
             mrnContactDetailsAnswer = None,
             mrnContactAddressAnswer = None,
-            basisOfClaimAnswer = Some(basisOfClaimAnswer),
+            basisOfClaimAnswer = basisOfClaimAnswer,
             bankAccountDetailsAnswer = Some(bankAccountDetailsAnswer),
             claimedReimbursementsAnswer = claimedReimbursementsAnswer,
             displayDeclaration = Some(displayDeclaration),

--- a/test/uk/gov/hmrc/cdsreimbursementclaim/services/ccs/CcsSubmissionServiceSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaim/services/ccs/CcsSubmissionServiceSpec.scala
@@ -22,7 +22,6 @@ import cats.data.EitherT
 import cats.syntax.all._
 import org.scalamock.handlers.{CallHandler0, CallHandler1, CallHandler2}
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.test.Helpers.await
@@ -48,7 +47,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 
-class CcsSubmissionServiceSpec() extends AnyWordSpec with Matchers with MockFactory with EitherValues {
+class CcsSubmissionServiceSpec() extends AnyWordSpec with Matchers with MockFactory {
 
   implicit val timeout: Timeout = Timeout(FiniteDuration(5, TimeUnit.SECONDS))
 


### PR DESCRIPTION
According with https://jira.tools.tax.service.gov.uk/browse/CDSR-1153 the basis of claims answer is mandatory. 
Currently if it is undefined the backend fails with an error.