### PR TITLE
Cdsr 2039 refactor fix 2

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/C285ClaimToEmailMapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/C285ClaimToEmailMapper.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaim.services.email
+
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.C285ClaimRequest
+import uk.gov.hmrc.cdsreimbursementclaim.models.email.{Email, EmailRequest}
+import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
+
+class C285ClaimToEmailMapper extends ClaimToEmailMapper[C285ClaimRequest] {
+  override def map(claim: C285ClaimRequest): Either[CdsError, EmailRequest] = {
+    val x = for {
+      email       <- claim.claim.contactInformation.emailAddress.toRight(
+                       CdsError("no email address provided with claim")
+                     )
+      contactName <- claim.claim.contactInformation.contactPerson.toRight(
+                       CdsError("no contact nam perovided with claim")
+                     )
+      claimAmount  = claim.claim.claims.map(_.claimAmount).toList.sum
+    } yield EmailRequest(
+      Email(email),
+      contactName,
+      claimAmount
+    )
+
+    x
+  }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/C285ClaimToEmailMapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/C285ClaimToEmailMapper.scala
@@ -27,7 +27,7 @@ class C285ClaimToEmailMapper extends ClaimToEmailMapper[C285ClaimRequest] {
                        CdsError("no email address provided with claim")
                      )
       contactName <- claim.claim.contactInformation.contactPerson.toRight(
-                       CdsError("no contact nam perovided with claim")
+                       CdsError("no contact name provided with claim")
                      )
       claimAmount  = claim.claim.claims.map(_.claimAmount).toList.sum
     } yield EmailRequest(

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/ClaimToEmailMapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/ClaimToEmailMapper.scala
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cdsreimbursementclaim.services.tpi05
+package uk.gov.hmrc.cdsreimbursementclaim.services.email
 
-import uk.gov.hmrc.cdsreimbursementclaim.models.Error
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.EisSubmitClaimRequest
 import uk.gov.hmrc.cdsreimbursementclaim.models.email.EmailRequest
+import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
 
-trait ClaimToTPI05Mapper[Claim] {
-  def map(claim: Claim): Either[Error, EisSubmitClaimRequest]
+trait ClaimToEmailMapper[Claim] {
+  def map(claim: Claim): Either[CdsError, EmailRequest]
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/OverpaymentsSingleClaimToEmailMapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/OverpaymentsSingleClaimToEmailMapper.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaim.services.email
+
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.SingleOverpaymentsClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaim.models.email.{Email, EmailRequest}
+import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
+
+class OverpaymentsSingleClaimToEmailMapper
+    extends ClaimToEmailMapper[(SingleOverpaymentsClaim, DisplayDeclaration, Option[DisplayDeclaration])] {
+  override def map(
+    claim: (SingleOverpaymentsClaim, DisplayDeclaration, Option[DisplayDeclaration])
+  ): Either[CdsError, EmailRequest] = {
+    val (overpaymentsClaim, _, _) = claim
+    for {
+      email       <- overpaymentsClaim.claimantInformation.contactInformation.emailAddress.toRight(
+                       CdsError("no email address provided with claim")
+                     )
+      contactName <- overpaymentsClaim.claimantInformation.contactInformation.contactPerson.toRight(
+                       CdsError("no contact name provided with claim")
+                     )
+      claimAmount  = overpaymentsClaim.reimbursementClaims.values.sum
+    } yield EmailRequest(
+      Email(email),
+      contactName,
+      claimAmount
+    )
+  }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/RejectedGoodsClaimToEmailMapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/RejectedGoodsClaimToEmailMapper.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaim.services.email
+
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.RejectedGoodsClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaim.models.email.{Email, EmailRequest}
+import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
+
+class RejectedGoodsClaimToEmailMapper[Claim <: RejectedGoodsClaim]
+    extends ClaimToEmailMapper[(Claim, List[DisplayDeclaration])] {
+  override def map(claim: (Claim, List[DisplayDeclaration])): Either[CdsError, EmailRequest] = {
+    val (rejectedGoodsClaim, _) = claim
+    for {
+      email       <- rejectedGoodsClaim.claimantInformation.contactInformation.emailAddress.toRight(
+                       CdsError("no email address provided with claim")
+                     )
+      contactName <- rejectedGoodsClaim.claimantInformation.contactInformation.contactPerson.toRight(
+                       CdsError("no contact nam perovided with claim")
+                     )
+      claimAmount  = rejectedGoodsClaim.totalReimbursementAmount
+    } yield EmailRequest(
+      Email(email),
+      contactName,
+      claimAmount
+    )
+  }
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/RejectedGoodsClaimToEmailMapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/RejectedGoodsClaimToEmailMapper.scala
@@ -30,7 +30,7 @@ class RejectedGoodsClaimToEmailMapper[Claim <: RejectedGoodsClaim]
                        CdsError("no email address provided with claim")
                      )
       contactName <- rejectedGoodsClaim.claimantInformation.contactInformation.contactPerson.toRight(
-                       CdsError("no contact nam perovided with claim")
+                       CdsError("no contact name provided with claim")
                      )
       claimAmount  = rejectedGoodsClaim.totalReimbursementAmount
     } yield EmailRequest(

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/ScheduledRejectedGoodsClaimToEmailMapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/ScheduledRejectedGoodsClaimToEmailMapper.scala
@@ -31,7 +31,7 @@ class ScheduledRejectedGoodsClaimToEmailMapper
                        CdsError("no email address provided with claim")
                      )
       contactName <- scheduledRejectedGoodsClaim.claimantInformation.contactInformation.contactPerson.toRight(
-                       CdsError("no contact nam perovided with claim")
+                       CdsError("no contact name provided with claim")
                      )
       claimAmount  = scheduledRejectedGoodsClaim.totalReimbursementAmount
     } yield EmailRequest(

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/ScheduledRejectedGoodsClaimToEmailMapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/ScheduledRejectedGoodsClaimToEmailMapper.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaim.services.email
+
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.ScheduledRejectedGoodsClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaim.models.email.{Email, EmailRequest}
+import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
+
+class ScheduledRejectedGoodsClaimToEmailMapper
+    extends ClaimToEmailMapper[(ScheduledRejectedGoodsClaim, DisplayDeclaration)] {
+
+  override def map(claim: (ScheduledRejectedGoodsClaim, DisplayDeclaration)): Either[CdsError, EmailRequest] = {
+    val (scheduledRejectedGoodsClaim, _) = claim
+    for {
+      email       <- scheduledRejectedGoodsClaim.claimantInformation.contactInformation.emailAddress.toRight(
+                       CdsError("no email address provided with claim")
+                     )
+      contactName <- scheduledRejectedGoodsClaim.claimantInformation.contactInformation.contactPerson.toRight(
+                       CdsError("no contact nam perovided with claim")
+                     )
+      claimAmount  = scheduledRejectedGoodsClaim.totalReimbursementAmount
+    } yield EmailRequest(
+      Email(email),
+      contactName,
+      claimAmount
+    )
+  }
+
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/SecuritiesClaimToEmailMapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/SecuritiesClaimToEmailMapper.scala
@@ -30,7 +30,7 @@ class SecuritiesClaimToEmailMapper extends ClaimToEmailMapper[(SecuritiesClaim, 
                        CdsError("no email address provided with claim")
                      )
       contactName <- securitiesClaim.claimantInformation.contactInformation.contactPerson.toRight(
-                       CdsError("no contact nam perovided with claim")
+                       CdsError("no contact name provided with claim")
                      )
       claimAmount  = securitiesClaim.securitiesReclaims.values.flatMap(_.values).sum
     } yield EmailRequest(

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/SecuritiesClaimToEmailMapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/SecuritiesClaimToEmailMapper.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaim.services.email
+
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.SecuritiesClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaim.models.email.{Email, EmailRequest}
+import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
+
+class SecuritiesClaimToEmailMapper extends ClaimToEmailMapper[(SecuritiesClaim, DisplayDeclaration)] {
+
+  override def map(claim: (SecuritiesClaim, DisplayDeclaration)): Either[CdsError, EmailRequest] = {
+    val (securitiesClaim, _) = claim
+    for {
+      email       <- securitiesClaim.claimantInformation.contactInformation.emailAddress.toRight(
+                       CdsError("no email address provided with claim")
+                     )
+      contactName <- securitiesClaim.claimantInformation.contactInformation.contactPerson.toRight(
+                       CdsError("no contact nam perovided with claim")
+                     )
+      claimAmount  = securitiesClaim.securitiesReclaims.values.flatMap(_.values).sum
+    } yield EmailRequest(
+      Email(email),
+      contactName,
+      claimAmount
+    )
+  }
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/package.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/email/package.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsreimbursementclaim.services
+
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.{MultipleRejectedGoodsClaim, SingleRejectedGoodsClaim}
+
+package object email {
+  implicit val c285ClaimToEmailMapper: C285ClaimToEmailMapper =
+    new C285ClaimToEmailMapper
+
+  implicit val overpaymentsSingleClaimToEmailMapper: OverpaymentsSingleClaimToEmailMapper =
+    new OverpaymentsSingleClaimToEmailMapper
+
+  implicit val singleRejectedGoodsClaimToEmailMapper: RejectedGoodsClaimToEmailMapper[SingleRejectedGoodsClaim] =
+    new RejectedGoodsClaimToEmailMapper[SingleRejectedGoodsClaim]
+
+  implicit val multipleRejectedGoodsClaimToEmailMapper: RejectedGoodsClaimToEmailMapper[MultipleRejectedGoodsClaim] =
+    new RejectedGoodsClaimToEmailMapper[MultipleRejectedGoodsClaim]
+
+  implicit val scheduledRejectedGoodsClaimToEmailMapper: ScheduledRejectedGoodsClaimToEmailMapper =
+    new ScheduledRejectedGoodsClaimToEmailMapper
+
+  implicit val securitiesClaimToEmailMapper: SecuritiesClaimToEmailMapper =
+    new SecuritiesClaimToEmailMapper
+}

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/C285ClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/C285ClaimToTPI05Mapper.scala
@@ -81,21 +81,6 @@ class C285ClaimToTPI05Mapper extends ClaimToTPI05Mapper[C285ClaimRequest] {
         }
       )).flatMap(_.verify)
 
-  override def mapEmailRequest(claim: C285ClaimRequest): Either[CdsError, EmailRequest] =
-    for {
-      email       <- claim.claim.contactInformation.emailAddress.toRight(
-                       CdsError("no email address provided with claim")
-                     )
-      contactName <- claim.claim.contactInformation.contactPerson.toRight(
-                       CdsError("no contact nam perovided with claim")
-                     )
-      claimAmount  = claim.claim.claims.map(_.claimAmount).toList.sum
-    } yield EmailRequest(
-      Email(email),
-      contactName,
-      claimAmount
-    )
-
   private def getEoriDetails(request: C285ClaimRequest): Either[CdsError, EoriDetails] =
     for {
       agentEoriNumber  <- request.claim.declarantDetails.map(_.EORI).toRight(CdsError("agent EORI is required"))

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/C285ClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/C285ClaimToTPI05Mapper.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.cdsreimbursementclaim.models.claim.{C285ClaimRequest, Street}
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim._
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.ClaimType.C285
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.{CaseType, Claimant, DeclarationMode, YesNo}
+import uk.gov.hmrc.cdsreimbursementclaim.models.email.{Email, EmailRequest}
 import uk.gov.hmrc.cdsreimbursementclaim.models.ids.MRN
 import uk.gov.hmrc.cdsreimbursementclaim.utils.BigDecimalOps
 
@@ -79,6 +80,21 @@ class C285ClaimToTPI05Mapper extends ClaimToTPI05Mapper[C285ClaimRequest] {
             )
         }
       )).flatMap(_.verify)
+
+  override def mapEmailRequest(claim: C285ClaimRequest): Either[CdsError, EmailRequest] =
+    for {
+      email       <- claim.claim.contactInformation.emailAddress.toRight(
+                       CdsError("no email address provided with claim")
+                     )
+      contactName <- claim.claim.contactInformation.contactPerson.toRight(
+                       CdsError("no contact nam perovided with claim")
+                     )
+      claimAmount  = claim.claim.claims.map(_.claimAmount).toList.sum
+    } yield EmailRequest(
+      Email(email),
+      contactName,
+      claimAmount
+    )
 
   private def getEoriDetails(request: C285ClaimRequest): Either[CdsError, EoriDetails] =
     for {

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/ClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/ClaimToTPI05Mapper.scala
@@ -18,8 +18,10 @@ package uk.gov.hmrc.cdsreimbursementclaim.services.tpi05
 
 import uk.gov.hmrc.cdsreimbursementclaim.models.Error
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.EisSubmitClaimRequest
+import uk.gov.hmrc.cdsreimbursementclaim.models.email.EmailRequest
 
 trait ClaimToTPI05Mapper[Claim] {
   def map(claim: Claim): Either[Error, EisSubmitClaimRequest]
+  def mapEmailRequest(claim: Claim): Either[Error, EmailRequest]
 
 }

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/OverpaymentsSingleClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/OverpaymentsSingleClaimToTPI05Mapper.scala
@@ -86,25 +86,6 @@ class OverpaymentsSingleClaimToTPI05Mapper
       )).flatMap(_.verify)
   }
 
-  override def mapEmailRequest(
-    claim: (SingleOverpaymentsClaim, DisplayDeclaration, Option[DisplayDeclaration])
-  ): Either[CdsError, EmailRequest] = {
-    val (singleOverpaymentsClaim, _, _) = claim
-    for {
-      email       <- singleOverpaymentsClaim.claimantInformation.contactInformation.emailAddress.toRight(
-                       CdsError("no email address provided with claim")
-                     )
-      contactName <- singleOverpaymentsClaim.claimantInformation.contactInformation.contactPerson.toRight(
-                       CdsError("no contact nam perovided with claim")
-                     )
-      claimAmount  = singleOverpaymentsClaim.reimbursementClaims.values.sum
-    } yield EmailRequest(
-      Email(email),
-      contactName,
-      claimAmount
-    )
-  }
-
   private def getMrnDetails(
     claim: SingleOverpaymentsClaim,
     displayDeclaration: DisplayDeclaration,

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/RejectedGoodsClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/RejectedGoodsClaimToTPI05Mapper.scala
@@ -70,23 +70,6 @@ class RejectedGoodsClaimToTPI05Mapper[Claim <: RejectedGoodsClaim]
       .withCaseType(claim.caseType)).flatMap(_.verify)
   }
 
-  override def mapEmailRequest(claim: (Claim, List[DisplayDeclaration])): Either[CdsError, EmailRequest] = {
-    val (rejectedGoodsClaim, _) = claim
-    for {
-      email       <- rejectedGoodsClaim.claimantInformation.contactInformation.emailAddress.toRight(
-                       CdsError("no email address provided with claim")
-                     )
-      contactName <- rejectedGoodsClaim.claimantInformation.contactInformation.contactPerson.toRight(
-                       CdsError("no contact nam perovided with claim")
-                     )
-      claimAmount  = rejectedGoodsClaim.totalReimbursementAmount
-    } yield EmailRequest(
-      Email(email),
-      contactName,
-      claimAmount
-    )
-  }
-
   private def getGoodsDetails(claim: Claim) =
     GoodsDetails(
       descOfGoods = Some(claim.detailsOfRejectedGoods),

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/ScheduledRejectedGoodsClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/ScheduledRejectedGoodsClaimToTPI05Mapper.scala
@@ -65,25 +65,6 @@ class ScheduledRejectedGoodsClaimToTPI05Mapper
       .withCaseType(claim.caseType)).flatMap(_.verify)
   }
 
-  override def mapEmailRequest(
-    claim: (ScheduledRejectedGoodsClaim, DisplayDeclaration)
-  ): Either[CdsError, EmailRequest] = {
-    val (scheduledRejectedGoodsClaim, _) = claim
-    for {
-      email       <- scheduledRejectedGoodsClaim.claimantInformation.contactInformation.emailAddress.toRight(
-                       CdsError("no email address provided with claim")
-                     )
-      contactName <- scheduledRejectedGoodsClaim.claimantInformation.contactInformation.contactPerson.toRight(
-                       CdsError("no contact nam perovided with claim")
-                     )
-      claimAmount  = scheduledRejectedGoodsClaim.totalReimbursementAmount
-    } yield EmailRequest(
-      Email(email),
-      contactName,
-      claimAmount
-    )
-  }
-
   private def getGoodsDetails(claim: ScheduledRejectedGoodsClaim) =
     GoodsDetails(
       descOfGoods = Some(claim.detailsOfRejectedGoods),

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/SecuritiesClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/SecuritiesClaimToTPI05Mapper.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim._
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.TemporaryAdmissionMethodOfDisposal.{ExportedInMultipleShipments, ExportedInSingleShipment}
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.{ExportMRN, ReasonForSecurity, ReimbursementMethod, ReimbursementParty, TemporaryAdmissionMethodOfDisposal}
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.DisplayDeclaration
-import uk.gov.hmrc.cdsreimbursementclaim.models.email.Email
+import uk.gov.hmrc.cdsreimbursementclaim.models.email.{Email, EmailRequest}
 import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.response
 
@@ -55,7 +55,7 @@ class SecuritiesClaimToTPI05Mapper extends ClaimToTPI05Mapper[(SecuritiesClaim, 
                                                                         .map(_.contactDetails.toRight(CdsError("The consignee contact information is missing")).map(_ => ()))
                                                                         .getOrElse(().asRight)
       consigneeDetails                                              = displayDeclaration.displayResponseDetail.consigneeDetails
-                                                                        .map(MRNInformation.fromConsigneeDetails(_))
+                                                                        .map(MRNInformation.fromConsigneeDetails)
                                                                         .getOrElse(declarantDetails)
       securities                                                    = displayDeclaration.displayResponseDetail.securityDetails.toList.flatten
       securityDetails                                              <- getSecurityDetails(securities, claim.securitiesReclaims)
@@ -143,6 +143,23 @@ class SecuritiesClaimToTPI05Mapper extends ClaimToTPI05Mapper[(SecuritiesClaim, 
         bankDetails = bankDetails
       )
       .withTemporaryAdmissionMethodOfDisposal(methodOfDisposalDetail)).flatMap(x => x.verify)
+  }
+
+  override def mapEmailRequest(claim: (SecuritiesClaim, DisplayDeclaration)): Either[CdsError, EmailRequest] = {
+    val (securitiesClaim, _) = claim
+    for {
+      email       <- securitiesClaim.claimantInformation.contactInformation.emailAddress.toRight(
+                       CdsError("no email address provided with claim")
+                     )
+      contactName <- securitiesClaim.claimantInformation.contactInformation.contactPerson.toRight(
+                       CdsError("no contact nam perovided with claim")
+                     )
+      claimAmount  = securitiesClaim.securitiesReclaims.values.flatMap(_.values).sum
+    } yield EmailRequest(
+      Email(email),
+      contactName,
+      claimAmount
+    )
   }
 
   private def getSecurityPaymentDetails(

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/SecuritiesClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/SecuritiesClaimToTPI05Mapper.scala
@@ -145,23 +145,6 @@ class SecuritiesClaimToTPI05Mapper extends ClaimToTPI05Mapper[(SecuritiesClaim, 
       .withTemporaryAdmissionMethodOfDisposal(methodOfDisposalDetail)).flatMap(x => x.verify)
   }
 
-  override def mapEmailRequest(claim: (SecuritiesClaim, DisplayDeclaration)): Either[CdsError, EmailRequest] = {
-    val (securitiesClaim, _) = claim
-    for {
-      email       <- securitiesClaim.claimantInformation.contactInformation.emailAddress.toRight(
-                       CdsError("no email address provided with claim")
-                     )
-      contactName <- securitiesClaim.claimantInformation.contactInformation.contactPerson.toRight(
-                       CdsError("no contact nam perovided with claim")
-                     )
-      claimAmount  = securitiesClaim.securitiesReclaims.values.flatMap(_.values).sum
-    } yield EmailRequest(
-      Email(email),
-      contactName,
-      claimAmount
-    )
-  }
-
   private def getSecurityPaymentDetails(
     claimantType: ClaimantType,
     bankAccountDetails: Option[BankAccountDetails],

--- a/test/uk/gov/hmrc/cdsreimbursementclaim/controllers/SubmitClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaim/controllers/SubmitClaimControllerSpec.scala
@@ -35,6 +35,7 @@ import uk.gov.hmrc.cdsreimbursementclaim.models.generators.OverpaymentsSingleCla
 import uk.gov.hmrc.cdsreimbursementclaim.models.generators.TPI05RequestGen._
 import uk.gov.hmrc.cdsreimbursementclaim.services.ClaimService
 import uk.gov.hmrc.cdsreimbursementclaim.services.ccs.{CcsSubmissionRequest, CcsSubmissionService, ClaimToDec64Mapper}
+import uk.gov.hmrc.cdsreimbursementclaim.services.email.{ClaimToEmailMapper, OverpaymentsSingleClaimToEmailMapper}
 import uk.gov.hmrc.cdsreimbursementclaim.services.tpi05.{ClaimToTPI05Mapper, OverpaymentsSingleClaimToTPI05Mapper}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.workitem.WorkItem
@@ -73,9 +74,16 @@ class SubmitClaimControllerSpec extends ControllerSpec with ScalaCheckPropertyCh
   private def mockC285ClaimSubmission(request: C285ClaimRequest)(
     response: Either[Error, ClaimSubmitResponse]
   ) =
-    (mockClaimService
-      .submitC285Claim(_: C285ClaimRequest)(_: HeaderCarrier, _: Request[_], _: ClaimToTPI05Mapper[C285ClaimRequest]))
-      .expects(request, *, *, *)
+    (
+      mockClaimService
+        .submitC285Claim(_: C285ClaimRequest)(
+          _: HeaderCarrier,
+          _: Request[_],
+          _: ClaimToTPI05Mapper[C285ClaimRequest],
+          _: ClaimToEmailMapper[C285ClaimRequest]
+        )
+      )
+      .expects(request, *, *, *, *)
       .returning(EitherT.fromEither[Future](response))
 
   private def mockSingleOverpaymentsClaimSubmission(request: SingleOverpaymentsClaimRequest)(
@@ -86,10 +94,11 @@ class SubmitClaimControllerSpec extends ControllerSpec with ScalaCheckPropertyCh
         .submitSingleOverpaymentsClaim(_: SingleOverpaymentsClaimRequest)(
           _: HeaderCarrier,
           _: Request[_],
-          _: OverpaymentsSingleClaimToTPI05Mapper
+          _: OverpaymentsSingleClaimToTPI05Mapper,
+          _: OverpaymentsSingleClaimToEmailMapper
         )
       )
-      .expects(request, *, *, *)
+      .expects(request, *, *, *, *)
       .returning(EitherT.fromEither[Future](response))
 
   private def mockRejectedGoodsClaimSubmission[Claim <: RejectedGoodsClaim](request: RejectedGoodsClaimRequest[Claim])(
@@ -101,10 +110,11 @@ class SubmitClaimControllerSpec extends ControllerSpec with ScalaCheckPropertyCh
           _: HeaderCarrier,
           _: Request[_],
           _: ClaimToTPI05Mapper[(Claim, List[DisplayDeclaration])],
+          _: ClaimToEmailMapper[(Claim, List[DisplayDeclaration])],
           _: Format[RejectedGoodsClaimRequest[Claim]]
         )
       )
-      .expects(request, *, *, *, *)
+      .expects(request, *, *, *, *, *)
       .returning(EitherT.fromEither[Future](response))
 
   private def mockMultipleRejectedGoodsClaimSubmission(request: RejectedGoodsClaimRequest[MultipleRejectedGoodsClaim])(
@@ -116,10 +126,11 @@ class SubmitClaimControllerSpec extends ControllerSpec with ScalaCheckPropertyCh
           _: HeaderCarrier,
           _: Request[_],
           _: ClaimToTPI05Mapper[(MultipleRejectedGoodsClaim, List[DisplayDeclaration])],
+          _: ClaimToEmailMapper[(MultipleRejectedGoodsClaim, List[DisplayDeclaration])],
           _: Format[RejectedGoodsClaimRequest[MultipleRejectedGoodsClaim]]
         )
       )
-      .expects(request, *, *, *, *)
+      .expects(request, *, *, *, *, *)
       .returning(EitherT.fromEither[Future](response))
 
   private def mockScheduledRejectedGoodsClaimSubmission(
@@ -132,10 +143,11 @@ class SubmitClaimControllerSpec extends ControllerSpec with ScalaCheckPropertyCh
         .submitScheduledRejectedGoodsClaim(_: RejectedGoodsClaimRequest[ScheduledRejectedGoodsClaim])(
           _: HeaderCarrier,
           _: Request[_],
+          _: ClaimToEmailMapper[(ScheduledRejectedGoodsClaim, DisplayDeclaration)],
           _: Format[RejectedGoodsClaimRequest[ScheduledRejectedGoodsClaim]]
         )
       )
-      .expects(request, *, *, *)
+      .expects(request, *, *, *, *)
       .returning(EitherT.fromEither[Future](response))
 
   private def mockCcsRequestEnqueue[A](


### PR DESCRIPTION
Refactored the mapping from claims to emailrequests into separate mapper classes with a common trait, similar to the TPI05 mappers