### PR TITLE
[CDSR-2043] set useExistingPaymentMethod in Securities only when bankDetails are set as well

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/ClaimService.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/ClaimService.scala
@@ -24,28 +24,41 @@ import cats.syntax.eq._
 import cats.syntax.option._
 import com.google.inject.ImplementedBy
 import play.api.http.Status.OK
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json.Format
+import play.api.libs.json.Json
 import play.api.mvc.Request
 import uk.gov.hmrc.cdsreimbursementclaim.connectors.ClaimConnector
 import uk.gov.hmrc.cdsreimbursementclaim.metrics.Metrics
 import uk.gov.hmrc.cdsreimbursementclaim.models.Error
-import uk.gov.hmrc.cdsreimbursementclaim.models.claim.audit.{SubmitClaimEvent, SubmitClaimResponseEvent}
-import uk.gov.hmrc.cdsreimbursementclaim.models.claim.{C285ClaimRequest, ClaimSubmitResponse, MultipleRejectedGoodsClaim, RejectedGoodsClaim, RejectedGoodsClaimRequest, ScheduledRejectedGoodsClaim, SecuritiesClaim, SecuritiesClaimRequest, SingleOverpaymentsClaimRequest}
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.{EisSubmitClaimRequest, EisSubmitClaimResponse}
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.C285ClaimRequest
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.ClaimSubmitResponse
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.MultipleRejectedGoodsClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.RejectedGoodsClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.RejectedGoodsClaimRequest
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.ScheduledRejectedGoodsClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.SecuritiesClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.SecuritiesClaimRequest
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.SingleOverpaymentsClaimRequest
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.audit.SubmitClaimEvent
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.audit.SubmitClaimResponseEvent
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.EisSubmitClaimRequest
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.EisSubmitClaimResponse
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.DisplayDeclaration
-import uk.gov.hmrc.cdsreimbursementclaim.models.email.EmailRequest
+import uk.gov.hmrc.cdsreimbursementclaim.models.ids.MRN
 import uk.gov.hmrc.cdsreimbursementclaim.services.audit.AuditService
-import uk.gov.hmrc.cdsreimbursementclaim.services.tpi05.{ClaimToTPI05Mapper, OverpaymentsSingleClaimToTPI05Mapper}
+import uk.gov.hmrc.cdsreimbursementclaim.services.email.ClaimToEmailMapper
+import uk.gov.hmrc.cdsreimbursementclaim.services.email.OverpaymentsSingleClaimToEmailMapper
+import uk.gov.hmrc.cdsreimbursementclaim.services.tpi05.ClaimToTPI05Mapper
+import uk.gov.hmrc.cdsreimbursementclaim.services.tpi05.OverpaymentsSingleClaimToTPI05Mapper
 import uk.gov.hmrc.cdsreimbursementclaim.utils.HttpResponseOps.HttpResponseOps
 import uk.gov.hmrc.cdsreimbursementclaim.utils.Logging
-import uk.gov.hmrc.cdsreimbursementclaim.utils.Logging._
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpResponse
 
-import javax.inject.{Inject, Singleton}
-import uk.gov.hmrc.cdsreimbursementclaim.models.ids.MRN
-import uk.gov.hmrc.cdsreimbursementclaim.services.email.{ClaimToEmailMapper, OverpaymentsSingleClaimToEmailMapper}
-
-import scala.concurrent.{ExecutionContext, Future}
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.util.Try
 
 @ImplementedBy(classOf[DefaultClaimService])

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/C285ClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/C285ClaimToTPI05Mapper.scala
@@ -17,13 +17,16 @@
 package uk.gov.hmrc.cdsreimbursementclaim.services.tpi05
 
 import cats.implicits.catsSyntaxEq
-import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
-import uk.gov.hmrc.cdsreimbursementclaim.models.claim.{C285ClaimRequest, Street}
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.C285ClaimRequest
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.Street
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim._
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.CaseType
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.ClaimType.C285
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.{CaseType, Claimant, DeclarationMode, YesNo}
-import uk.gov.hmrc.cdsreimbursementclaim.models.email.{Email, EmailRequest}
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.Claimant
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.DeclarationMode
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.YesNo
 import uk.gov.hmrc.cdsreimbursementclaim.models.ids.MRN
+import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
 import uk.gov.hmrc.cdsreimbursementclaim.utils.BigDecimalOps
 
 class C285ClaimToTPI05Mapper extends ClaimToTPI05Mapper[C285ClaimRequest] {

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/ClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/ClaimToTPI05Mapper.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.cdsreimbursementclaim.services.tpi05
 
 import uk.gov.hmrc.cdsreimbursementclaim.models.Error
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.EisSubmitClaimRequest
-import uk.gov.hmrc.cdsreimbursementclaim.models.email.EmailRequest
 
 trait ClaimToTPI05Mapper[Claim] {
   def map(claim: Claim): Either[Error, EisSubmitClaimRequest]

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/OverpaymentsSingleClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/OverpaymentsSingleClaimToTPI05Mapper.scala
@@ -17,13 +17,19 @@
 package uk.gov.hmrc.cdsreimbursementclaim.services.tpi05
 
 import cats.implicits.catsSyntaxEq
-import uk.gov.hmrc.cdsreimbursementclaim.models.claim.{ClaimantType, SingleOverpaymentsClaim, TaxCode, TypeOfClaimAnswer}
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.response.{NdrcDetails => DeclarationNdrcDetails}
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.ClaimantType
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.SingleOverpaymentsClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.TaxCode
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.TypeOfClaimAnswer
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim._
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.CaseType
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.ClaimType.C285
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.{CaseType, Claimant, DeclarationMode, YesNo}
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.Claimant
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.DeclarationMode
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.YesNo
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.DisplayDeclaration
-import uk.gov.hmrc.cdsreimbursementclaim.models.email.{Email, EmailRequest}
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.response.{NdrcDetails => DeclarationNdrcDetails}
+import uk.gov.hmrc.cdsreimbursementclaim.models.email.Email
 import uk.gov.hmrc.cdsreimbursementclaim.models.ids.MRN
 import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
 import uk.gov.hmrc.cdsreimbursementclaim.utils.BigDecimalOps

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/RejectedGoodsClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/RejectedGoodsClaimToTPI05Mapper.scala
@@ -16,17 +16,20 @@
 
 package uk.gov.hmrc.cdsreimbursementclaim.services.tpi05
 
-import cats.implicits.{catsSyntaxEq, catsSyntaxOption}
-import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
-import uk.gov.hmrc.cdsreimbursementclaim.models.claim.{Country, RejectedGoodsClaim}
+import cats.implicits.catsSyntaxEq
+import cats.implicits.catsSyntaxOption
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.Country
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.RejectedGoodsClaim
 import uk.gov.hmrc.cdsreimbursementclaim.models.dates.TemporalAccessorOps
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim._
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.ClaimType.CE1179
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.Claimant
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.DisplayResponseDetail
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.response.ConsigneeDetails
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.{DisplayDeclaration, DisplayResponseDetail}
-import uk.gov.hmrc.cdsreimbursementclaim.models.email.{Email, EmailRequest}
+import uk.gov.hmrc.cdsreimbursementclaim.models.email.Email
 import uk.gov.hmrc.cdsreimbursementclaim.models.ids.MRN
+import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
 import uk.gov.hmrc.cdsreimbursementclaim.utils.BigDecimalOps
 
 // todo CDSR-1795 TPI05 creation and validation - factor out common code

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/ScheduledRejectedGoodsClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/ScheduledRejectedGoodsClaimToTPI05Mapper.scala
@@ -16,17 +16,18 @@
 
 package uk.gov.hmrc.cdsreimbursementclaim.services.tpi05
 
-import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
 import uk.gov.hmrc.cdsreimbursementclaim.models.claim.Country
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.ScheduledRejectedGoodsClaim
 import uk.gov.hmrc.cdsreimbursementclaim.models.dates.TemporalAccessorOps
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim._
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.ClaimType.CE1179
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.Claimant
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.{DisplayDeclaration, DisplayResponseDetail}
-import uk.gov.hmrc.cdsreimbursementclaim.models.email.{Email, EmailRequest}
-import uk.gov.hmrc.cdsreimbursementclaim.utils.BigDecimalOps
-import uk.gov.hmrc.cdsreimbursementclaim.models.claim.ScheduledRejectedGoodsClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.DisplayDeclaration
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.DisplayResponseDetail
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.response.ConsigneeDetails
+import uk.gov.hmrc.cdsreimbursementclaim.models.email.Email
+import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
+import uk.gov.hmrc.cdsreimbursementclaim.utils.BigDecimalOps
 
 class ScheduledRejectedGoodsClaimToTPI05Mapper
     extends ClaimToTPI05Mapper[(ScheduledRejectedGoodsClaim, DisplayDeclaration)] {

--- a/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/SecuritiesClaimToTPI05Mapper.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaim/services/tpi05/SecuritiesClaimToTPI05Mapper.scala
@@ -16,23 +16,38 @@
 
 package uk.gov.hmrc.cdsreimbursementclaim.services.tpi05
 
+import cats.data.Validated.Invalid
+import cats.data.Validated.Valid
 import cats.implicits.catsSyntaxEq
 import cats.syntax.either._
-import uk.gov.hmrc.cdsreimbursementclaim.models.claim.securities.{DeclarantReferenceNumber, DeclarationId, ProcedureCode}
-import uk.gov.hmrc.cdsreimbursementclaim.models.claim.{ClaimantType, SecuritiesClaim, SecurityDetail, TaxCode, TaxReclaimDetail}
-import uk.gov.hmrc.cdsreimbursementclaim.models.dates.{AcceptanceDate, EisBasicDate}
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.response.{BankAccountDetails, BtaSource, SecurityDetails, TaxDetails}
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.ClaimantType
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.SecuritiesClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.SecurityDetail
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.TaxCode
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.TaxReclaimDetail
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.securities.DeclarantReferenceNumber
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.securities.DeclarationId
+import uk.gov.hmrc.cdsreimbursementclaim.models.claim.securities.ProcedureCode
+import uk.gov.hmrc.cdsreimbursementclaim.models.dates.AcceptanceDate
+import uk.gov.hmrc.cdsreimbursementclaim.models.dates.EisBasicDate
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim._
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.TemporaryAdmissionMethodOfDisposal.{ExportedInMultipleShipments, ExportedInSingleShipment}
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.{ExportMRN, ReasonForSecurity, ReimbursementMethod, ReimbursementParty, TemporaryAdmissionMethodOfDisposal}
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.ExportMRN
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.ReasonForSecurity
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.ReimbursementMethod
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.ReimbursementParty
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.TemporaryAdmissionMethodOfDisposal
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.TemporaryAdmissionMethodOfDisposal.ExportedInMultipleShipments
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.TemporaryAdmissionMethodOfDisposal.ExportedInSingleShipment
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.DisplayDeclaration
-import uk.gov.hmrc.cdsreimbursementclaim.models.email.{Email, EmailRequest}
-import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.response
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.response.BankAccountDetails
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.response.BtaSource
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.response.SecurityDetails
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.declaration.response.TaxDetails
+import uk.gov.hmrc.cdsreimbursementclaim.models.email.Email
+import uk.gov.hmrc.cdsreimbursementclaim.models.{Error => CdsError}
 
 import java.time.LocalDate
-import cats.data.Validated.Valid
-import cats.data.Validated.Invalid
 
 class SecuritiesClaimToTPI05Mapper extends ClaimToTPI05Mapper[(SecuritiesClaim, DisplayDeclaration)] {
 
@@ -159,7 +174,8 @@ class SecuritiesClaimToTPI05Mapper extends ClaimToTPI05Mapper[(SecuritiesClaim, 
             s"Multiple payment methods returned: [${paymentMethods.mkString(", ")}]"
           )
         case "001" :: Nil                                                              => Right((Some(bankDetails), Some(true), Some(ReimbursementMethod.BankTransfer)))
-        case "002" :: Nil                                                              => Right((None, Some(true), Some(ReimbursementMethod.Deferment)))
+        case "002" :: Nil                                                              => Right((None, Some(false), Some(ReimbursementMethod.Deferment)))
+        case "003" :: Nil                                                              => Right((None, Some(false), Some(ReimbursementMethod.PayableOrder)))
         case "004" :: Nil                                                              => Right((None, Some(false), Some(ReimbursementMethod.GeneralGuarantee)))
         case "005" :: Nil                                                              => Right((None, Some(false), Some(ReimbursementMethod.IndividualGuarantee)))
         case unsupported :: Nil                                                        =>

--- a/test/uk/gov/hmrc/cdsreimbursementclaim/models/generators/TPI05RequestGen.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaim/models/generators/TPI05RequestGen.scala
@@ -16,22 +16,33 @@
 
 package uk.gov.hmrc.cdsreimbursementclaim.models.generators
 
-import cats.implicits.catsSyntaxTuple2Semigroupal
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
 import org.scalacheck.magnolia._
-import org.scalacheck.{Arbitrary, Gen}
 import uk.gov.hmrc.cdsreimbursementclaim.models.claim.ClaimSubmitResponse
-import uk.gov.hmrc.cdsreimbursementclaim.models.dates.{ISO8601DateTime, ISOLocalDate, TemporalAccessorOps}
+import uk.gov.hmrc.cdsreimbursementclaim.models.dates.ISO8601DateTime
+import uk.gov.hmrc.cdsreimbursementclaim.models.dates.ISOLocalDate
+import uk.gov.hmrc.cdsreimbursementclaim.models.dates.TemporalAccessorOps
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim._
-import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.ClaimType.{C285, CE1179}
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.ClaimType.C285
+import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums.ClaimType.CE1179
 import uk.gov.hmrc.cdsreimbursementclaim.models.eis.claim.enums._
-import uk.gov.hmrc.cdsreimbursementclaim.models.generators.AddressGen.{genCountry, genPostcode}
-import uk.gov.hmrc.cdsreimbursementclaim.models.generators.BankAccountDetailsGen.{genAccountName, genAccountNumber, genSortCode}
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.AddressGen.genCountry
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.AddressGen.genPostcode
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.BankAccountDetailsGen.genAccountName
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.BankAccountDetailsGen.genAccountNumber
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.BankAccountDetailsGen.genSortCode
 import uk.gov.hmrc.cdsreimbursementclaim.models.generators.C285ClaimGen.genBasisOfClaim
 import uk.gov.hmrc.cdsreimbursementclaim.models.generators.CMAEligibleGen.genWhetherCMAEligible
-import uk.gov.hmrc.cdsreimbursementclaim.models.generators.ContactDetailsGen.{genEmail, genUkPhoneNumber}
-import uk.gov.hmrc.cdsreimbursementclaim.models.generators.IdGen.{genEori, genMRN}
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.ContactDetailsGen.genEmail
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.ContactDetailsGen.genUkPhoneNumber
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.IdGen.genEori
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.IdGen.genMRN
 import uk.gov.hmrc.cdsreimbursementclaim.models.generators.PaymentMethodGen.genPaymentMethod
-import uk.gov.hmrc.cdsreimbursementclaim.models.generators.RejectedGoodsClaimGen.{genBasisOfRejectedGoodsClaim, genInspectionAddressType, genInspectionDate, genMethodOfDisposal}
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.RejectedGoodsClaimGen.genBasisOfRejectedGoodsClaim
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.RejectedGoodsClaimGen.genInspectionAddressType
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.RejectedGoodsClaimGen.genInspectionDate
+import uk.gov.hmrc.cdsreimbursementclaim.models.generators.RejectedGoodsClaimGen.genMethodOfDisposal
 import uk.gov.hmrc.cdsreimbursementclaim.models.generators.TaxCodesGen.genTaxCode
 import uk.gov.hmrc.cdsreimbursementclaim.models.ids.Eori
 import uk.gov.hmrc.cdsreimbursementclaim.utils.BigDecimalOps


### PR DESCRIPTION
Fixing CDSR-2043 (useExistingPaymentMethod) for Securities plus a cleanup of imports